### PR TITLE
Clean up integration testing aws credentials

### DIFF
--- a/docs/testing/integration-testing.md
+++ b/docs/testing/integration-testing.md
@@ -13,10 +13,9 @@ Run these tests against **deployed cloud resources**. A first pass against an em
 
 [jUnit](https://junit.org/junit5/) is used for all testing. For integration tests, it's possible to just use the same default constructor that the Lambda service will use in the cloud.
 
-```java App.java focus=28
+```java App.java focus=19
 // This is an integration test as it requires an actual AWS account.
 // It assumes that a DynamoDB table with name "tickets" exists on AWS in US-EAST-1
-// and reads AWS Credentials from ~/.aws/credentials with default profile
 @ExtendWith(SystemStubsExtension.class)
 public class TicketFunctionIntegrationTest {
 
@@ -26,64 +25,6 @@ public class TicketFunctionIntegrationTest {
     .region(Region.US_EAST_1)
     .build();
   private List<String> ticketList = new ArrayList<>();
-
-  @BeforeAll
-  public static void setup() {
-    ProfileCredentialsProvider credentialsProvider = ProfileCredentialsProvider.create("default");
-    AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
-    environmentVariables.set("AWS_ACCESS_KEY_ID", awsCredentials.accessKeyId());
-    environmentVariables.set("AWS_SECRET_ACCESS_KEY", awsCredentials.secretAccessKey());
-  }
-
-  @AfterEach
-  public void cleanup() {
-    DynamoTestUtil.deleteFromDDBTable(ddbClient, ticketList);
-    ticketList.clear();
-  }
-
-  @ParameterizedTest
-  @Event(value = "events/apigw_request_1.json", type = APIGatewayProxyRequestEvent.class)
-  public void testPutTicket(APIGatewayProxyRequestEvent event, EnvironmentVariables environmentVariables) {
-    TicketFunction function = new TicketFunction();
-    APIGatewayProxyResponseEvent response = function.handleRequest(event, null);
-    Assertions.assertNotNull(response);
-    Assertions.assertNotNull(response.getBody());
-    String uuidStr = response.getBody();
-    Assertions.assertNotNull(uuidStr);
-    ticketList.add(uuidStr.substring(1, uuidStr.length() - 1));
-    DynamoTestUtil.validateItems(ticketList, ddbClient);
-  }
-}
-
-```
-
----
-
-## Configure Credentials
-
-Before each test run, the AWS credentials are configured. In this instance, the credentials are pulled from the _`default`_ profile. Equally, the ACCESS_KEY and SECRET_KEY could be pulled directly from environment variables. In a CICD environment like GitHub Actions these keys can be stored in Secret store.
-
-```java App.java focus=14:20
-// This is an integration test as it requires an actual AWS account.
-// It assumes that a DynamoDB table with name "tickets" exists on AWS in US-EAST-1
-// and reads AWS Credentials from ~/.aws/credentials with default profile
-@ExtendWith(SystemStubsExtension.class)
-public class TicketFunctionIntegrationTest {
-
-  @SystemStub
-  private static EnvironmentVariables environmentVariables;
-  private final DynamoDbClient ddbClient = DynamoDbClient.builder()
-    .region(Region.US_EAST_1)
-    .build();
-  private List<String> ticketList = new ArrayList<>();
-
-  @BeforeAll
-  public static void setup() {
-    ProfileCredentialsProvider credentialsProvider = ProfileCredentialsProvider.create("default");
-    AwsCredentials awsCredentials = credentialsProvider.resolveCredentials();
-    environmentVariables.set("AWS_ACCESS_KEY_ID", awsCredentials.accessKeyId());
-    environmentVariables.set("AWS_SECRET_ACCESS_KEY", awsCredentials.secretAccessKey());
-  }
 
   @AfterEach
   public void cleanup() {
@@ -116,7 +57,6 @@ Fundamentally, we write tests to ensure that the code we deploy into production 
 ```java App.java focus=11:20
 // This is an integration test as it requires an actual AWS account.
 // It assumes that a DynamoDB table with name "tickets" exists on AWS in US-EAST-1
-// and reads AWS Credentials from ~/.aws/credentials with default profile
 @ExtendWith(SystemStubsExtension.class)
 public class TicketFunctionIntegrationTest {
 
@@ -147,7 +87,6 @@ Throughout the test run the created tickets are collected into a list. That list
 ```java App.java focus=7:11
 // This is an integration test as it requires an actual AWS account.
 // It assumes that a DynamoDB table with name "tickets" exists on AWS in US-EAST-1
-// and reads AWS Credentials from ~/.aws/credentials with default profile
 @ExtendWith(SystemStubsExtension.class)
 public class TicketFunctionIntegrationTest {
 


### PR DESCRIPTION
## Description

Removed manipulation of credentials provider.

## Motivation

As the code was not actually using the manipulated credentials provider it appeared to be redundant and was falling back to the default credentials provider anyway.

The default DefaultCredentialsProvider which uses a chain looks at the following in order:

> AWS credentials provider chain that looks for credentials in this order:
> Java System Properties - aws.accessKeyId and aws.secretAccessKey
> Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
> Web Identity Token credentials from system properties or environment variables
> Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
> Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI” environment variable is set and security manager has permission to access the variable,
> Instance profile credentials delivered through the Amazon EC2 metadata service

Source: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html

By using the default credentials provider this allows the end-user or system executing the test the ability to configure this externally allowing tests to be executed in a CI environment or a local machine with no change to the test code.